### PR TITLE
Локальные скрипты для запуска Caddy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -429,3 +429,5 @@ Caddyfile
 runCaddy
 run
 stop
+localCaddyfile
+localRunCaddy


### PR DESCRIPTION
Я добавил файлы localCaddyfile и localRunCaddy в .gitignore.
Теперь можно пользоваться этими файлами, чтобы локально настроить правильные пути для запуска caddy.
